### PR TITLE
ci: add macOS test workflow & prune unused config

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,18 +1,59 @@
 name: test
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
-  test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
-    
+  lint:
+    runs-on: macos-latest
+    timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-    - name: Install dotfiles
-      run: sh -c "$(curl -fsLS chezmoi.io/get)" -- init --apply unvalley
+      - name: Install tools
+        run: brew install fish just
+
+      - name: Lint fish config
+        shell: bash
+        run: |
+          set -e
+          shopt -s nullglob
+          files=(
+            dot_config/private_fish/private_config.fish
+            dot_config/private_fish/private_conf.d/*.fish
+          )
+          for f in "${files[@]}"; do
+            echo "::group::$f"
+            fish --no-execute "$f"
+            echo "::endgroup::"
+          done
+
+      - name: Validate justfile
+        run: |
+          just --unstable --fmt --check
+          just --list
+
+      - name: Validate Brewfile syntax
+        run: brew bundle list --file=Brewfile >/dev/null
+
+  apply:
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install chezmoi
+        run: brew install chezmoi
+
+      - name: Apply dotfiles
+        run: chezmoi apply --source "$PWD" --destination "$HOME" --verbose
+
+      - name: Verify key files exist
+        run: |
+          set -e
+          test -f "$HOME/.config/fish/config.fish"
+          test -f "$HOME/.config/starship.toml"
+          test -f "$HOME/.gitconfig"
+          test -f "$HOME/CLAUDE.md"

--- a/Brewfile
+++ b/Brewfile
@@ -51,32 +51,16 @@ brew "tealdeer"                    # Fast tldr client
 brew "daipeihust/tap/im-select"    # Input method switcher
 
 # =============================================================================
-# Image / Media
-# =============================================================================
-brew "aom"                         # AV1 codec
-brew "jpeg-xl"                     # JPEG XL format
-brew "webp"                        # WebP format
-
-# =============================================================================
 # Languages & Toolchains
 # =============================================================================
 brew "go"                          # Go
 brew "llvm"                        # LLVM toolchain
-brew "luajit"                      # LuaJIT
 brew "rustup-init"                 # Rust installer
 
 # =============================================================================
 # System libraries
 # =============================================================================
 brew "gd"                          # Graphics library
-brew "gdk-pixbuf"                  # Image loading
-brew "glib"                        # GLib core library
-brew "harfbuzz"                    # Text shaping
-brew "krb5"                        # Kerberos
-brew "libomp"                      # LLVM OpenMP
-brew "pango"                       # Text layout
-brew "qemu"                        # Machine emulator
-brew "qt"                          # Qt framework
 
 # =============================================================================
 # Terminal multiplexer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ All first-time setup lives in `justfile`. Run `just --list` to see recipes
 - **Terminal**: WezTerm, with Zellij multiplexer.
 - **Editors**: VS Code (primary) and Zed, both with Vim mode.
 - **Git**: delta pager, conventional commits via `czg`.
-- **Package managers**: Homebrew (system), Volta (Node), rustup (Rust), proto (polyglot).
+- **Package managers**: Homebrew (system), rustup (Rust).
 
 ## Known gotchas
 

--- a/dot_config/private_fish/private_config.fish
+++ b/dot_config/private_fish/private_config.fish
@@ -12,38 +12,15 @@ set -x EXSQL_BQ_RUNNING_PROJECT exsql-sandbox
 fish_add_path $EXSQL_HOME/target/debug
 
 # ---- Rust ----
-fish_add_path ~/.rustup/toolchains/stable-x86_64-apple-darwin/bin
 fish_add_path ~/.rustup/toolchains/stable-aarch64-apple-darwin/bin
 fish_add_path ~/.rustup/toolchains/nightly-aarch64-apple-darwin/bin
 fish_add_path $HOME/.cargo/bin
-
-# ---- Go ----
-set -x GOENV_ROOT $HOME/.goenv
-fish_add_path $GOENV_ROOT/bin
-fish_add_path $GOROOT/bin
-fish_add_path $GOPATH/bin
-
-# ---- Python ----
-set -x PYENV_ROOT $HOME/.pyenv
-fish_add_path $PYENV_ROOT/bin
-
-# ---- Node.js (Volta) ----
-set -gx VOLTA_HOME "$HOME/.volta"
-if test -d $VOLTA_HOME/bin
-    fish_add_path $VOLTA_HOME/bin
-end
 
 # ---- AWS ----
 set -gx AWS_DEFAULT_REGION ap-northeast-1
 
 # ---- Google Cloud SDK ----
 set -x CLOUDSDK_PYTHON python3
-
-# ---- Haskell (ghcup) ----
-set -q GHCUP_INSTALL_BASE_PREFIX[1]; or set GHCUP_INSTALL_BASE_PREFIX $HOME
-if test -f $HOME/.ghcup/env
-    fish_add_path $HOME/.cabal/bin $HOME/.ghcup/bin
-end
 
 # ---- fzf ----
 function fzf

--- a/dot_prototools
+++ b/dot_prototools
@@ -1,4 +1,0 @@
-node = "~22"
-
-[settings]
-auto-install = true

--- a/justfile
+++ b/justfile
@@ -65,8 +65,3 @@ setup-gh-extensions:
 setup-rust:
     rustup-init
     rustc -v
-
-# Install Node.js via Volta
-setup-nodejs:
-    volta install node
-    node -v


### PR DESCRIPTION
## Summary
- Replace the placeholder GitHub Actions workflow with two macOS jobs: **lint** (fish parse-check, `just --fmt --check`, Brewfile parse) and **apply** (`chezmoi apply` against the checkout + key-file assertions).
- Drop ubuntu-latest from the matrix; this repo is macOS-only.
- Trigger on `push: main` + `pull_request` (was: all pushes).
- Prune dead configuration: goenv/pyenv/ghcup paths, x86_64 rustup toolchain, Volta and proto references, and Brewfile entries that were either unused (`luajit`, `libomp`, `qemu`, `qt`) or only pulled in transitively (`gdk-pixbuf`, `glib`, `harfbuzz`, `pango`, `krb5`, `aom`, `jpeg-xl`, `webp`).

## Test plan
- [ ] **lint** job passes (fish parse, justfile fmt, Brewfile parse)
- [ ] **apply** job passes (chezmoi applies cleanly, key files exist in \$HOME)
- [ ] Local: \`chezmoi apply\` works against the new tree
- [ ] Local: \`fish\` starts cleanly with the trimmed config