### PR TITLE
ci: bump actions/checkout to v6 (Node.js 24)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install tools
         run: brew install fish just
@@ -42,7 +42,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install chezmoi
         run: brew install chezmoi


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v4 to v6 to silence the Node.js 20 deprecation warning. v6 runs on Node.js 24.

## Test plan
- [ ] Both jobs (lint, apply) still pass with the new action version
- [ ] No deprecation annotations in the run summary